### PR TITLE
Allow the extension to make requests to any url with https.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   },
   "permissions": [
     "activeTab",
-    "https://ajax.googleapis.com/"
+    "https://*/"
   ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }


### PR DESCRIPTION
Required for cross site requests to test PouchDB's sync functionality with remote servers
